### PR TITLE
Fixes #8; excludes intents as attributes for SIMMC-Fashion

### DIFF
--- a/mm_action_prediction/tools/extract_actions_fashion.py
+++ b/mm_action_prediction/tools/extract_actions_fashion.py
@@ -131,6 +131,11 @@ def extract_info_attributes(round_datum):
             ii in intent
             for ii in ("DA:ASK:GET", "DA:ASK:CHECK", "DA:INFORM:GET")
         ):
+            # If there is no attribute added, default to info.
+            if "." not in intent:
+                get_attribute_matches.append("info")
+                continue
+
             attribute = intent.split(".")[-1]
             if attribute == "info":
                 new_matches = [


### PR DESCRIPTION
Due to some inconsistencies in the intent annotations, about 0.5% of the `SpecifyInfo` actions have intents in their attributes. This commit fixes those by explicitly checking for presence of attribute while extracting them by verifying the presence of a `.attribute` suffix.