### PR TITLE
F1 score computation for empty API arguments list

### DIFF
--- a/mm_action_prediction/tools/action_evaluation.py
+++ b/mm_action_prediction/tools/action_evaluation.py
@@ -3,13 +3,11 @@
 Author(s): Satwik Kottur
 """
 
-
-from absl import app, flags
 import collections
 import json
 
 import numpy as np
-
+from absl import app, flags
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string(
@@ -72,6 +70,10 @@ def evaluate_action_prediction(gt_actions, model_actions):
                     gt_key_vals = supervision[key]
                     model_key_vals = round_datum["attributes"][key]
                     if not len(gt_key_vals):
+                        if not len(model_key_vals):
+                            matches['attributes'].append(1.0)
+                        else:
+                            matches['attributes'].append(0.)
                         continue
                     # For fashion, this is a list -- multi label prediction.
                     if isinstance(gt_key_vals, list):

--- a/mm_action_prediction/tools/action_evaluation.py
+++ b/mm_action_prediction/tools/action_evaluation.py
@@ -3,20 +3,18 @@
 Author(s): Satwik Kottur
 """
 
-
-from absl import app, flags
 import collections
 import json
 
 import numpy as np
-
+from absl import app, flags
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string(
-    "action_json_path", "data/furniture_api_calls.json", "Ground truth API calls"
+    "action_json_path", "annotations/fashion_devtest_dials_api_calls.json", "Ground truth API calls"
 )
 flags.DEFINE_string(
-    "model_output_path", None, "Action API predictions by the model"
+    "model_output_path", "model_out2.json", "Action API predictions by the model"
 )
 
 
@@ -72,6 +70,10 @@ def evaluate_action_prediction(gt_actions, model_actions):
                     gt_key_vals = supervision[key]
                     model_key_vals = round_datum["attributes"][key]
                     if not len(gt_key_vals):
+                        if not len(model_key_vals):
+                            matches['attributes'].append(1.0)
+                        else:
+                            matches['attributes'].append(0.)
                         continue
                     # For fashion, this is a list -- multi label prediction.
                     if isinstance(gt_key_vals, list):


### PR DESCRIPTION
Whenever the API arguments ground truth list is empty, the `mm_action_prediction/tools/action_evaluation.py` script does not evaluate the goodness of the model prediction. Thus it does not penalize a model that predicts N arguments and it does not reward a model that predicts exactly 0 arguments as the ground truth. I know that the recall computation is not feasible for empty ground truth and I want to propose this 1-0 method that assigns an f1 score of 1.0 if the model arguments prediction list is empty, given that the ground truth arguments list is empty, and 0 if model arguments prediction list is not empty and the ground truth list is empty.

The final results are pretty different in terms of scores so please consider this possible change carefully. I think that the major concern could be the fact that an empty list of arguments is always present with a `None` or `AddToCart` so I don't know if this could create an unfair and biased score.
Thank you.