### PR TITLE
Added filtered attributes ground truth for action prediction scorer

### DIFF
--- a/mm_action_prediction/tools/action_evaluation.py
+++ b/mm_action_prediction/tools/action_evaluation.py
@@ -31,6 +31,9 @@ IGNORE_ATTRIBUTES = [
     "focus"  # fashion
 ]
 
+EVALUATED_FASHION_ATTRIBUTES = {"availableSizes", "price", "brand", "customerRating", "info", "color"}
+
+
 
 def evaluate_action_prediction(gt_actions, model_actions):
     """Evaluates action prediction using the raw data and model predictions.
@@ -78,6 +81,8 @@ def evaluate_action_prediction(gt_actions, model_actions):
                         assert isinstance(model_key_vals, list), (
                             "Model should also predict a list for attributes"
                         )
+                        for ii, attr in enumerate(supervision[key]):
+                            gt_key_vals[ii] = attr if attr in EVALUATED_FASHION_ATTRIBUTES else "other"
                         recall = np.mean(
                             [(ii in model_key_vals) for ii in gt_key_vals]
                         )


### PR DESCRIPTION
The baselines are trained to predict attributes for each action as a multilabel prediction problem where each attribute can assume value in a set of 7 possible outcomes: {"availableSizes", "price", "brand", "customerRating", "info", "color"} + "others".

The variety of attribute values included in the fashion dataset is instead 33. During the training, all the attributes of the training set not included in the desired subset are replaced with the value "others".
Anyway, this mechanism is not included in the scorer, resulting in a comparison between 33 possible ground truth values vs only 7 that can be predicted by the model.

This pull request adds the attribute values filtering on the ground truth labels also.
