### PR TITLE
Fixed retrieval evaluation script

### DIFF
--- a/mm_action_prediction/tools/retrieval_evaluation.py
+++ b/mm_action_prediction/tools/retrieval_evaluation.py
@@ -39,10 +39,10 @@ def evaluate_response_retrieval(gt_responses, model_scores):
 
 
 def main(_):
-    print("Reading: {}".format(FLAGS.data_json_path))
-    with open(FLAGS.data_json_file, "r") as file_id:
+    print("Reading: {}".format(FLAGS.retrieval_json_path))
+    with open(FLAGS.retrieval_json_path, "r") as file_id:
         gt_responses = json.load(file_id)
-    print("Reading: {}".format(FLAGS.model_output_path))
+    print("Reading: {}".format(FLAGS.model_score_path))
     with open(FLAGS.model_score_path, "r") as file_id:
         model_scores = json.load(file_id)
     retrieval_metrics = evaluate_response_retrieval(gt_responses, model_scores)


### PR DESCRIPTION
The retrieval evaluation script presents the wrong names for the flags "retrieval_json_path" and "model_score_path". This pull request fixes the error in the `main` function.