### PR TITLE
Fixed text spans and brand name errors in simmc fashion & furniture.

### DIFF
--- a/data/simmc_fashion/fashion_dev_dials.json
+++ b/data/simmc_fashion/fashion_dev_dials.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a6dcd956dd0dde0b9ed064bf8790885569d7d0e553da164752c52d1310cf16d
-size 10388068
+oid sha256:a561e0bb90475bf84ca69f21f3d7c66b04853ac92eb36112704d9fd9895e718b
+size 10390760

--- a/data/simmc_fashion/fashion_devtest_dials.json
+++ b/data/simmc_fashion/fashion_devtest_dials.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:847d3af9c2c3d120042ed4ea90d7baf5a9ec4f95217465db2c39f21842731fe2
-size 16189803
+oid sha256:18a9a2bb2fefb8eb64f5cca705a107b4135e0c1bcba7687446fd8678449ec335
+size 16193739

--- a/data/simmc_fashion/fashion_train_dials.json
+++ b/data/simmc_fashion/fashion_train_dials.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a18781a3d74c93d4c9d85458501671745e2cd7c96f70894daceb6bb4cf636b04
-size 62870458
+oid sha256:efde37cb1f00009e5ed63d70d5576d8ae5d7e1a5c922e1031f20e2aa9911a723
+size 62887336

--- a/data/simmc_furniture/furniture_dev_dials.json
+++ b/data/simmc_furniture/furniture_dev_dials.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec22928eab9636faf45b2fc25c35029563af5d732394d1c63df68b3ae37893d1
-size 19189208
+oid sha256:fc8d2cb184d7599221b1dff0ee8da16f26c0c0b8bf1d2451cfcfe1db4634ef5c
+size 19192164

--- a/data/simmc_furniture/furniture_devtest_dials.json
+++ b/data/simmc_furniture/furniture_devtest_dials.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a97c6cb28da5fed3e6b000a4c8a0a7b3ba50f5ce99648900dd9929bd7d14de17
-size 30438472
+oid sha256:22d46eb16d2b476be1b318dd78c00ada335dd8cef897fcb4bdd6fc4ab8ea1ae5
+size 30443325

--- a/data/simmc_furniture/furniture_train_dials.json
+++ b/data/simmc_furniture/furniture_train_dials.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4202df84f750a8dc403ed8d7d0e0c0fbe94c2f87353a5fb31dbe92bdeafb402
-size 122359043
+oid sha256:c392fabd7d3008cc137cbde02e2efeb82f219914fbb6f27e3a394000b6f41a40
+size 122377679


### PR DESCRIPTION
Span annotations values were erroneous, the start and end span indices have been corrected now. Brand names have been copied into the dialogues erroneously, which have been corrected as well.