### PR TITLE
Fix support import in mm_action_prediction/tools/build_multimodal_inputs.py

### DIFF
--- a/mm_action_prediction/tools/build_multimodal_inputs.py
+++ b/mm_action_prediction/tools/build_multimodal_inputs.py
@@ -15,7 +15,7 @@ import numpy as np
 from nltk.tokenize import word_tokenize
 from tqdm import tqdm as progressbar
 
-from tools import support
+import support
 
 
 FLAGS = flags.FLAGS


### PR DESCRIPTION
The previous import (`from tools import support`) gave the following error with Python 3.8.5 on Ubuntu 20.04:
```
Saving dictionary: ../data/simmc_fashion/fashion_vocabulary.json
Saving embeddings: ../data/simmc_fashion/fashion_asset_embeds.npy
Traceback (most recent call last):
  File "tools/build_multimodal_inputs.py", line 18, in <module>
    from tools import support
ModuleNotFoundError: No module named 'tools'
Traceback (most recent call last):
  File "tools/build_multimodal_inputs.py", line 18, in <module>
    from tools import support
ModuleNotFoundError: No module named 'tools'
Traceback (most recent call last):
  File "tools/build_multimodal_inputs.py", line 18, in <module>
    from tools import support
ModuleNotFoundError: No module named 'tools'
Traceback (most recent call last):
  File "tools/extract_attribute_vocabulary.py", line 149, in <module>
    extract_action_attributes(parsed_args)
  File "tools/extract_attribute_vocabulary.py", line 41, in extract_action_attributes
    data = np.load(args["train_npy_path"], allow_pickle=True)[()]
  File "/home/$USER/path/simmc/venv/lib/python3.8/site-packages/numpy/lib/npyio.py", line 416, in load
    fid = stack.enter_context(open(os_fspath(file), "rb"))
FileNotFoundError: [Errno 2] No such file or directory: '../data/simmc_fashion/fashion_train_dials_mm_inputs.npy'
```