### PR TITLE
s,np.bool\b,bool,

### DIFF
--- a/mm_action_prediction/loaders/loader_base.py
+++ b/mm_action_prediction/loaders/loader_base.py
@@ -104,7 +104,7 @@ class LoaderParent:
         # int32 get mapped to int64 and float to double
         if numpy_array.dtype == np.int32 or numpy_array.dtype == np.int64:
             new_type = torch.int64
-        elif numpy_array.dtype == np.bool:
+        elif numpy_array.dtype == bool:
             new_type = torch.bool
         else:
             new_type = torch.float

--- a/mm_action_prediction/loaders/loader_simmc.py
+++ b/mm_action_prediction/loaders/loader_simmc.py
@@ -461,7 +461,7 @@ class DataloaderSIMMC(loaders.LoaderParent):
             {
                 "user_utt": enc_in,
                 "user_utt_len": enc_len,
-                "dialog_mask": np.ones((1, 1), dtype=np.bool),
+                "dialog_mask": np.ones((1, 1), dtype=bool),
                 "round_id": np.array([round_id], dtype="int32"),
             }
         )


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/Generic-Grouping/pull/16

X-link: https://github.com/facebookresearch/Detectron/pull/1047

X-link: https://github.com/facebookincubator/zstrong/pull/582

`np.bool` and `bool` are identical, but the former is removed from Numpy-1.24.X.

Differential Revision: D49196618


